### PR TITLE
txpool: introduce max_tx_gas_limit feature to enforce per-transaction gas limits

### DIFF
--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -69,9 +69,9 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.gas-limit", default_value_t = ETHEREUM_BLOCK_GAS_LIMIT_30M)]
     pub enforced_gas_limit: u64,
 
-    /// Maximum gas limit for individual transactions (0 = no limit). Transactions exceeding this limit will be rejected by the transaction pool
-    #[arg(long = "txpool.max-tx-gas", default_value_t = 0)]
-    pub max_tx_gas_limit: u64,
+    /// Maximum gas limit for individual transactions. Transactions exceeding this limit will be rejected by the transaction pool
+    #[arg(long = "txpool.max-tx-gas")]
+    pub max_tx_gas_limit: Option<u64>,
 
     /// Price bump percentage to replace an already existing blob transaction
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
@@ -144,7 +144,7 @@ impl Default for TxPoolArgs {
             price_bump: DEFAULT_PRICE_BUMP,
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
             enforced_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            max_tx_gas_limit: 0,
+            max_tx_gas_limit: None,
             blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
             max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
             max_cached_entries: DEFAULT_MAX_CACHED_BLOBS,

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -69,6 +69,10 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.gas-limit", default_value_t = ETHEREUM_BLOCK_GAS_LIMIT_30M)]
     pub enforced_gas_limit: u64,
 
+    /// Maximum gas limit for individual transactions (0 = no limit). Transactions exceeding this limit will be rejected by the transaction pool
+    #[arg(long = "txpool.max-tx-gas", default_value_t = 0)]
+    pub max_tx_gas_limit: u64,
+
     /// Price bump percentage to replace an already existing blob transaction
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
     pub blob_transaction_price_bump: u128,
@@ -140,6 +144,7 @@ impl Default for TxPoolArgs {
             price_bump: DEFAULT_PRICE_BUMP,
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
             enforced_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            max_tx_gas_limit: 0,
             blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
             max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
             max_cached_entries: DEFAULT_MAX_CACHED_BLOBS,
@@ -190,6 +195,7 @@ impl RethTransactionPoolConfig for TxPoolArgs {
             },
             minimal_protocol_basefee: self.minimal_protocol_basefee,
             gas_limit: self.enforced_gas_limit,
+            max_tx_gas_limit: self.max_tx_gas_limit,
             pending_tx_listener_buffer_size: self.pending_tx_listener_buffer_size,
             new_tx_listener_buffer_size: self.new_tx_listener_buffer_size,
             max_new_pending_txs_notifications: self.max_new_pending_txs_notifications,

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -693,6 +693,9 @@ pub enum RpcPoolError {
     /// When the transaction exceeds the block gas limit
     #[error("exceeds block gas limit")]
     ExceedsGasLimit,
+    /// When the transaction gas limit exceeds the maximum transaction gas limit
+    #[error("exceeds max transaction gas limit")]
+    MaxTxGasLimitExceeded,
     /// Thrown when a new transaction is added to the pool, but then immediately discarded to
     /// respect the tx fee exceeds the configured cap
     #[error("tx fee ({max_tx_fee_wei} wei) exceeds the configured cap ({tx_fee_cap_wei} wei)")]
@@ -767,6 +770,7 @@ impl From<InvalidPoolTransactionError> for RpcPoolError {
         match err {
             InvalidPoolTransactionError::Consensus(err) => Self::Invalid(err.into()),
             InvalidPoolTransactionError::ExceedsGasLimit(_, _) => Self::ExceedsGasLimit,
+            InvalidPoolTransactionError::MaxTxGasLimitExceeded(_, _) => Self::MaxTxGasLimitExceeded,
             InvalidPoolTransactionError::ExceedsFeeCap { max_tx_fee_wei, tx_fee_cap_wei } => {
                 Self::ExceedsFeeCap { max_tx_fee_wei, tx_fee_cap_wei }
             }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -52,8 +52,8 @@ pub struct PoolConfig {
     pub minimal_protocol_basefee: u64,
     /// The max gas limit for transactions in the pool
     pub gas_limit: u64,
-    /// Maximum gas limit for individual transactions (0 = no limit)
-    pub max_tx_gas_limit: u64,
+    /// Maximum gas limit for individual transactions (None = no limit)
+    pub max_tx_gas_limit: Option<u64>,
     /// How to handle locally received transactions:
     /// [`TransactionOrigin::Local`](TransactionOrigin).
     pub local_transactions_config: LocalTransactionConfig,
@@ -90,7 +90,7 @@ impl Default for PoolConfig {
             price_bumps: Default::default(),
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
             gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            max_tx_gas_limit: 0,
+            max_tx_gas_limit: None,
             local_transactions_config: Default::default(),
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -52,6 +52,8 @@ pub struct PoolConfig {
     pub minimal_protocol_basefee: u64,
     /// The max gas limit for transactions in the pool
     pub gas_limit: u64,
+    /// Maximum gas limit for individual transactions (0 = no limit)
+    pub max_tx_gas_limit: u64,
     /// How to handle locally received transactions:
     /// [`TransactionOrigin::Local`](TransactionOrigin).
     pub local_transactions_config: LocalTransactionConfig,
@@ -88,6 +90,7 @@ impl Default for PoolConfig {
             price_bumps: Default::default(),
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
             gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            max_tx_gas_limit: 0,
             local_transactions_config: Default::default(),
             pending_tx_listener_buffer_size: PENDING_TX_LISTENER_BUFFER_SIZE,
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -218,6 +218,9 @@ pub enum InvalidPoolTransactionError {
     /// respect the size limits of the pool.
     #[error("transaction's gas limit {0} exceeds block's gas limit {1}")]
     ExceedsGasLimit(u64, u64),
+    /// Thrown when a transaction's gas limit exceeds the configured maximum per-transaction limit.
+    #[error("transaction's gas limit {0} exceeds maximum per-transaction gas limit {1}")]
+    MaxTxGasLimitExceeded(u64, u64),
     /// Thrown when a new transaction is added to the pool, but then immediately discarded to
     /// respect the tx fee exceeds the configured cap
     #[error("tx fee ({max_tx_fee_wei} wei) exceeds the configured cap ({tx_fee_cap_wei} wei)")]
@@ -316,6 +319,7 @@ impl InvalidPoolTransactionError {
                 }
             }
             Self::ExceedsGasLimit(_, _) => true,
+            Self::MaxTxGasLimitExceeded(_, _) => true,
             Self::ExceedsFeeCap { max_tx_fee_wei: _, tx_fee_cap_wei: _ } => true,
             Self::ExceedsMaxInitCodeSize(_, _) => true,
             Self::OversizedData(_, _) => true,


### PR DESCRIPTION
**Description**

This PR adds a configurable maximum gas limit for individual transactions in the reth transaction pool. The feature allows node operators to reject transactions that exceed a specified gas limit, providing additional control over resource usage and transaction size.

Key changes:
- Adds `--txpool.max-tx-gas` CLI argument to configure the maximum gas limit per transaction
- Implements validation logic to reject transactions exceeding the configured limit
- Uses `Option<u64>` where `None` disables the limit (default behavior)

**Tests**

Added comprehensive unit tests covering:
- Transaction validation when max gas limit is exceeded (should reject)
- Transaction validation when max gas limit is disabled (should accept)
- Transaction validation when transaction is within the configured limit (should accept)
- Proper error propagation through the transaction pool
- Integration with the existing transaction validation pipeline

**Additional context**

By default, transactions can use as much gas as is available to an entire block. This is reasonable on Ethereum mainnet where the block gas limit can be executed in a small fraction of the block time, but on high throughput rollups, it allows worst case transactions to push execution time beyond the block time—sometimes far beyond the block time.  Flashblocks introduce an even smaller constraint of one-tenth of a block.

Both state growth and gas target increases change the equilibrium for worst case transactions that the latest opcode pricing was intended to achieve. In between opcode repricings, we need a way to mitigate this problem. A per-transaction gas maximum prevents a single large worst case transaction (e.g. XEN) from stalling the chain, and limits the excess execution time that a block full of worst case transactions can cause.

The limit can be set based on how underpriced we expect opcodes to become before we fork to reprice them. For instance, a 10x underpriced opcode can 10x execution time without a transaction gas maximum. With a transaction gas maximum of 1/10th of the block gas limit, a 10x underpriced opcode can only double the execution time. A 5x underpriced opcode would be able to 1.5x the execution time with the same limit, and a 20x underpriced opcode would 3x the execution time.

[EIP 7825](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7825.md) aims to introduce a similar per-transaction gas limit at 30 million gas that would apply to both the txpool and block validation. High throughput rollups will typically want a lower limit chosen in relation to the block gas limit, and single-sequencer rollups can avoid block validation rules that require a hard fork to adjust as gas dynamics evolve.